### PR TITLE
Provide user object via interface

### DIFF
--- a/pong_frontend/src/api/userApi.ts
+++ b/pong_frontend/src/api/userApi.ts
@@ -1,5 +1,15 @@
+var fetchAddress = 'http://localhost:3000/';
+
 export const getUsers = async () => {
-  const response = await fetch('http://localhost:3000/api/users');
-  const json = (await response.json());
-  return json;
+  	const response = await fetch(fetchAddress + 'users');
+  	const json = (await response.json());
+	return json;
+};
+
+export const createUser = async () => {
+	const response = await fetch(fetchAddress + 'users');
+	console.log(response.text);
+
+	const json = (await response.json());
+	return json;
 };

--- a/pong_frontend/src/components/MainDivSelector.tsx
+++ b/pong_frontend/src/components/MainDivSelector.tsx
@@ -22,17 +22,16 @@ export enum main_div_mode_t {
 
 interface MainDivProps
 {
-//   userID: number;
-  user: User;
+  userID: number;
   mode: main_div_mode_t;
   mode_set: React.Dispatch<React.SetStateAction<main_div_mode_t>>;
 }
 
-const MainDivSelector: React.FC<MainDivProps> = ({/*userID, */mode, mode_set}) => {
+const MainDivSelector: React.FC<MainDivProps> = ({userID, mode, mode_set}) => {
 	var userID = 1;
   switch (mode){
     case main_div_mode_t.HOME_PAGE:
-      return (<Welcome_MainDiv />);
+      return (<Welcome_MainDiv userID={userID}/>);
 	case main_div_mode_t.FRIEND_PROFILE:
 		return (<Friend_Profile_MainDiv userID={userID} mode_set={mode_set} />);
 	case main_div_mode_t.CHAT:

--- a/pong_frontend/src/components/MainDivSelector.tsx
+++ b/pong_frontend/src/components/MainDivSelector.tsx
@@ -6,41 +6,43 @@ import Friend_Profile_MainDiv from './main_div/Friend_Profile_MainDiv';
 import Leaderboard_MainDiv from './main_div/Leaderboard_MainDiv';
 // import Chat_MainDiv from './main_div/Chat_MainDiv';
 import Arena_Chat_MainDiv from './main_div/Arena_Chat';
-
-
+import Settings_MainDiv from './main_div/Settings_MainDiv';
+import { User } from '../interfaces/user.interface';
 
 export enum main_div_mode_t {
   ERROR_PAGE = -1,
-  WELCOME_PAGE = 0,
-  PROFILE = 1,
-  FRIENDS_LIST = 2, 
-  MATCH_HISTORY = 3,
-  SETTINGS = 4,
-  CHAT = 5,
-  GAME = 6,
-  FRIIEND_PROFILE = 7,
-  LEADERBORAD = 8
+  HOME_PAGE = 0,
+  FRIEND_PROFILE = 1,
+  CHAT = 2,
+  GAME = 3,
+  PROFILE = 4,
+  SETTINGS = 5,
+  LEADERBORAD = 8,
 }
 
 interface MainDivProps
 {
-  userID: number;
+//   userID: number;
+  user: User;
   mode: main_div_mode_t;
   mode_set: React.Dispatch<React.SetStateAction<main_div_mode_t>>;
 }
 
-const MainDivSelector: React.FC<MainDivProps> = ({userID, mode, mode_set}) => {
+const MainDivSelector: React.FC<MainDivProps> = ({/*userID, */mode, mode_set}) => {
+	var userID = 1;
   switch (mode){
-    case main_div_mode_t.WELCOME_PAGE:
-      return (<Welcome_MainDiv userID={userID} />);
-    case main_div_mode_t.PROFILE:
-      return (<Profile_MainDiv userID={userID} mode_set={mode_set} />);
-    case main_div_mode_t.FRIIEND_PROFILE:
-      return (<Friend_Profile_MainDiv userID={userID} mode_set={mode_set} />);
-    case main_div_mode_t.LEADERBORAD:
-      return (<Leaderboard_MainDiv/>);
-    case main_div_mode_t.CHAT:
-      return (<Arena_Chat_MainDiv/>)
+    case main_div_mode_t.HOME_PAGE:
+      return (<Welcome_MainDiv />);
+	case main_div_mode_t.FRIEND_PROFILE:
+		return (<Friend_Profile_MainDiv userID={userID} mode_set={mode_set} />);
+	case main_div_mode_t.CHAT:
+		return (<Arena_Chat_MainDiv/>)
+	case main_div_mode_t.PROFILE:
+		return (<Profile_MainDiv userID={userID} mode_set={mode_set} />);
+	case main_div_mode_t.LEADERBORAD:
+      	return (<Leaderboard_MainDiv/>);
+	case main_div_mode_t.SETTINGS:
+		return (<Settings_MainDiv userID={userID} mode_set={mode_set} />);
     default:
       mode_set(main_div_mode_t.ERROR_PAGE);
       return (<Error_MainDiv />);

--- a/pong_frontend/src/components/UserStartPage.tsx
+++ b/pong_frontend/src/components/UserStartPage.tsx
@@ -1,30 +1,56 @@
 import React, {useState} from 'react';
 import MainDivSelector, {main_div_mode_t} from './MainDivSelector';
+import CSS from 'csstype';
 
 
 interface StartPageProps
 {
-  id: number;
+//   id: number;
 }
 
-const UserStartPage: React.FC<StartPageProps> = ({id}) => {
-  const [mode, mode_set] = useState<main_div_mode_t>(main_div_mode_t.WELCOME_PAGE);
+const UserStartPage: React.FC<StartPageProps> = () => {
+  const [mode, mode_set] = useState<main_div_mode_t>(main_div_mode_t.HOME_PAGE);
 
-  return (<div>
+  	const pageStyle: CSS.Properties = {
+		backgroundColor: 'rgba(3, 3, 3, 1)',
+		height: '100%',
+		width: '100%',
+		position: 'absolute',
+		alignItems: 'center',
+		flexDirection: 'column',
+		textAlign: 'center',
+		borderColor: 'green',
+		borderWidth: '5px',
+	}
+
+  	const buttonStyle: CSS.Properties = {
+		backgroundColor: 'rgba(254, 8, 16, 1)',
+		position: 'relative',
+		height:'40px',
+		width:'160px',
+		fontFamily: 'Shlop',
+		fontSize: '24px',
+		alignSelf: 'center',
+		borderRadius: '6px',
+		border: 'none',
+		color:'white',
+		top:'4px',
+		margin:'4px',
+	}
+
+  return (<div style={pageStyle}>
             <header>
-              <button onClick={() => mode_set(main_div_mode_t.PROFILE)}>Profie</button>
-              <button onClick={() => mode_set(main_div_mode_t.FRIIEND_PROFILE)}>Friends</button>
-              <button onClick={() => mode_set(main_div_mode_t.LEADERBORAD)}>Leaderboard</button>
-              <button>Blocked</button>
-              <button>Random match</button>
-              <button onClick={() => mode_set(main_div_mode_t.CHAT)}>Chat</button>
-              <button>Match History</button>
-              <button>Setting</button>
+              <button style={buttonStyle} onClick={() => mode_set(main_div_mode_t.HOME_PAGE)}>Home</button>
+              <button style={buttonStyle} onClick={() => mode_set(main_div_mode_t.FRIEND_PROFILE)}>Friends</button>
+              <button style={buttonStyle} onClick={() => mode_set(main_div_mode_t.CHAT)}>Chat</button>
+              <button style={buttonStyle}>Play</button>
+              <button style={buttonStyle} onClick={() => mode_set(main_div_mode_t.PROFILE)}>Profile</button>
+			  <button style={buttonStyle} onClick={() => mode_set(main_div_mode_t.LEADERBORAD)}>Leaderboard</button>
+              <button style={buttonStyle} onClick={() => mode_set(main_div_mode_t.SETTINGS)}>Settings</button>
             </header>
             <div style={{ width: '100%', height: '500px', backgroundColor: 'lightgray' }}>
-              <MainDivSelector userID={id} mode={mode} mode_set={mode_set} />
+              <MainDivSelector mode={mode} mode_set={mode_set} />
             </div>
-            
           </div>);
 };
 

--- a/pong_frontend/src/components/UserStartPage.tsx
+++ b/pong_frontend/src/components/UserStartPage.tsx
@@ -5,11 +5,12 @@ import CSS from 'csstype';
 
 interface StartPageProps
 {
-//   id: number;
+  id: number;
 }
 
 const UserStartPage: React.FC<StartPageProps> = () => {
   const [mode, mode_set] = useState<main_div_mode_t>(main_div_mode_t.HOME_PAGE);
+  const [userID, userID_set] = useState<main_div_mode_t>(main_div_mode_t.HOME_PAGE);
 
   	const pageStyle: CSS.Properties = {
 		backgroundColor: 'rgba(3, 3, 3, 1)',
@@ -49,7 +50,7 @@ const UserStartPage: React.FC<StartPageProps> = () => {
               <button style={buttonStyle} onClick={() => mode_set(main_div_mode_t.SETTINGS)}>Settings</button>
             </header>
             <div style={{ width: '100%', height: '500px', backgroundColor: 'lightgray' }}>
-              <MainDivSelector mode={mode} mode_set={mode_set} />
+              <MainDivSelector userID={userID} mode={mode} mode_set={mode_set} />
             </div>
           </div>);
 };

--- a/pong_frontend/src/components/main_div/Profile_MainDiv.tsx
+++ b/pong_frontend/src/components/main_div/Profile_MainDiv.tsx
@@ -31,7 +31,7 @@ const Profile_MainDiv: React.FC<ProfileProps> = ({userID, mode_set}) => {
                 <p>Welcome {userID}. This is your profile on server {idTxt}. </p> 
                 <br/> 
                 <p>Search for our friends here:</p>
-                <button onClick={() => mode_set(main_div_mode_t.FRIIEND_PROFILE)}>Search friends</button>
+                <button onClick={() => mode_set(main_div_mode_t.FRIEND_PROFILE)}>Search friends</button>
               </div>
               <Private_Div/>
             </div>)

--- a/pong_frontend/src/interfaces/user.interface.tsx
+++ b/pong_frontend/src/interfaces/user.interface.tsx
@@ -1,0 +1,45 @@
+import React, { createContext, useState, ReactNode } from 'react';
+import { Channel } from './channel.interface';
+
+export interface User {
+	username: string,
+	userID: number,
+	avatarPath: string,
+	wins: number,
+	losses: number,
+	points: number,
+	status: string,
+	achievementsCSV: string,
+	passwordHash: string,
+	friends: User[],
+	befriendedBy: User[],
+	blocked: User[],
+	blockedBy: User[],
+	adminChannels: Channel[],
+	blockedChannels: Channel[],
+	channels: Channel[],
+}
+
+interface UserContextProps {
+  user: User | null;
+  setUser: React.Dispatch<React.SetStateAction<User | null>>;
+}
+
+interface CreateUserProps {
+	onUserCreated: (user: User) => void;
+}
+
+export const UserContext = createContext<UserContextProps>({
+  user: null,
+  setUser: () => {},
+});
+
+export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [user, setUser] = useState<User | null>(null);
+
+  return (
+    <UserContext.Provider value={{ user, setUser }}>
+      {children}
+    </UserContext.Provider>
+  );
+};


### PR DESCRIPTION
I left in some changes for the main layout too. I removed some pages we probably won't need and now we have a selection of 6 pages where I still want to move Settings into the profile, but that in another PR.

The user object should be available now by importing `User` from the user.interface. This is just providing the User object. I left out all other things to not break anything with my code that still has bugs and errors